### PR TITLE
JL - Added PUT (edit) endpoint for a single record in UCSBSubjects table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -28,14 +28,29 @@ import javax.validation.Valid;
 import java.util.Optional;
 
 
+
+
 @Api(description = "UCSBSubjects")
 @RequestMapping("/api/UCSBSubjects/")
 @RestController
 @Slf4j
 public class UCSBSubjectController extends ApiController {
 
+    public class UCSBSubjectOrError {
+        Long id;
+        UCSBSubject uCSBSubject;
+        ResponseEntity<String> error;
+        public UCSBSubjectOrError(Long id) {
+        this.id = id;
+    }
+    }
+
     @Autowired
     UCSBSubjectRepository uCSBSubjectRepository;
+
+
+    @Autowired
+    ObjectMapper mapper;
 
     @ApiOperation(value = "List all UCSB subjects")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
@@ -71,4 +86,43 @@ public class UCSBSubjectController extends ApiController {
         UCSBSubject savedUCSBSubject = uCSBSubjectRepository.save(uCSBSubject);
         return savedUCSBSubject;
     }
+
+
+    
+    @ApiOperation(value = "Get record of UCSB Subject with id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("")
+    public ResponseEntity<String> getUCSBSubjectById123_admin(
+            @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
+        loggingService.logMethod();
+
+        UCSBSubjectOrError toe = new UCSBSubjectOrError(id);
+
+        toe = doesUCSBSubjectExist(toe);
+        if (toe.error != null) {
+            return toe.error;
+        }
+
+        String body = mapper.writeValueAsString(toe.uCSBSubject);
+        return ResponseEntity.ok().body(body);
+    }
+
+    public UCSBSubjectOrError doesUCSBSubjectExist(UCSBSubjectOrError toe) {
+
+        Optional<UCSBSubject> optionalUCSBSubject = uCSBSubjectRepository.findById(toe.id);
+
+        if (optionalUCSBSubject.isEmpty()) {
+            toe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("subject with id %d not found", toe.id));
+        } else {
+            toe.uCSBSubject = optionalUCSBSubject.get();
+        }
+        return toe;
+    }
+    
+
+    
+
+    
 }

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -120,10 +120,40 @@ public class UCSBSubjectController extends ApiController {
         }
         return toe;
     }
+        public UCSBSubjectOrError doesUCSBSubjectExist1(UCSBSubjectOrError toe) {
 
+        Optional<UCSBSubject> optionalUCSBSubject = uCSBSubjectRepository.findById(toe.id);
+
+        if (optionalUCSBSubject.isEmpty()) {
+            toe.error = ResponseEntity
+                    .badRequest()
+                    .body(String.format("record %d not found", toe.id));
+        } else {
+            toe.uCSBSubject = optionalUCSBSubject.get();
+        }
+        return toe;
+    }
+
+    @ApiOperation(value = "Delete a UCSB Subject by ID")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @DeleteMapping("")
+    public ResponseEntity<String> deleteUCSBSubject(
+            @ApiParam("id") @RequestParam Long id) {
+        loggingService.logMethod();
+
+        UCSBSubjectOrError toe = new UCSBSubjectOrError(id);
+
+        toe = doesUCSBSubjectExist1(toe);
+        if (toe.error != null) {
+            return toe.error;
+        }
+
+        uCSBSubjectRepository.deleteById(id);
+        return ResponseEntity.ok().body(String.format("record %d deleted", id));
+
+    }
     
     
-
     
 
     

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -53,7 +53,7 @@ public class UCSBSubjectController extends ApiController {
     ObjectMapper mapper;
 
     @ApiOperation(value = "List all UCSB subjects")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("/all")
     public Iterable<UCSBSubject> allUCSBSubjects() {
         loggingService.logMethod();

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -28,8 +28,8 @@ import javax.validation.Valid;
 import java.util.Optional;
 
 
-@Api(description = "UCSB Subjects")
-@RequestMapping("/api/systemInfo")
+@Api(description = "UCSBSubjects")
+@RequestMapping("/api/UCSBSubjects/")
 @RestController
 @Slf4j
 public class UCSBSubjectController extends ApiController {
@@ -39,7 +39,7 @@ public class UCSBSubjectController extends ApiController {
 
     @ApiOperation(value = "List all UCSB subjects")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
-    @GetMapping("/api/UCSBSubjects/all")
+    @GetMapping("/all")
     public Iterable<UCSBSubject> allUCSBSubjects() {
         loggingService.logMethod();
         Iterable<UCSBSubject> subjects = uCSBSubjectRepository.findAll();
@@ -49,7 +49,7 @@ public class UCSBSubjectController extends ApiController {
 
     @ApiOperation(value = "Create a new UCSB subject")
     @PreAuthorize("hasRole('ROLE_USER')")
-    @PostMapping("/api/UCSBSubjects/post")
+    @PostMapping("/post")
     public UCSBSubject postUCSBSubject(
             @ApiParam("subjectCode") @RequestParam String subjectCode,
             @ApiParam("subjectTranslation") @RequestParam String subjectTranslation,

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -90,7 +90,7 @@ public class UCSBSubjectController extends ApiController {
 
     
     @ApiOperation(value = "Get record of UCSB Subject with id")
-    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
     public ResponseEntity<String> getUCSBSubjectById123_admin(
             @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
@@ -114,7 +114,7 @@ public class UCSBSubjectController extends ApiController {
         if (optionalUCSBSubject.isEmpty()) {
             toe.error = ResponseEntity
                     .badRequest()
-                    .body(String.format("subject with id %d not found", toe.id));
+                    .body(String.format("id %d not found", toe.id));
         } else {
             toe.uCSBSubject = optionalUCSBSubject.get();
         }

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -154,7 +154,7 @@ public class UCSBSubjectController extends ApiController {
     }
 
 
-    @ApiOperation(value = "Update a single subject (regardless of ownership, admin only, can't change ownership)")
+    @ApiOperation(value = "Update a single subject ")
     @PreAuthorize("hasRole('ROLE_USER')")
     @PutMapping("")
     public ResponseEntity<String> putUCSBSubjectById(

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -152,6 +152,33 @@ public class UCSBSubjectController extends ApiController {
         return ResponseEntity.ok().body(String.format("record %d deleted", id));
 
     }
+
+
+    @ApiOperation(value = "Update a single subject (regardless of ownership, admin only, can't change ownership)")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PutMapping("")
+    public ResponseEntity<String> putUCSBSubjectById(
+            @ApiParam("id") @RequestParam Long id,
+            @RequestBody @Valid UCSBSubject incomingUCSBSubject) throws JsonProcessingException {
+        loggingService.logMethod();
+
+        UCSBSubjectOrError toe = new UCSBSubjectOrError(id);
+
+        toe = doesUCSBSubjectExist(toe);
+        if (toe.error != null) {
+            return toe.error;
+        }
+
+        // Even the admin can't change the user; they can change other details
+        // but not that.
+
+        //User previousUser = toe.todo.getUser();
+        //incomingTodo.setUser(previousUser);
+        uCSBSubjectRepository.save(incomingUCSBSubject);
+
+        String body = mapper.writeValueAsString(incomingUCSBSubject);
+        return ResponseEntity.ok().body(body);
+    }
     
     
     

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 
 
 @Api(description = "UCSBSubjects")
-@RequestMapping("/api/UCSBSubjects/")
+@RequestMapping("/api/UCSBSubjects")
 @RestController
 @Slf4j
 public class UCSBSubjectController extends ApiController {

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -1,0 +1,74 @@
+package edu.ucsb.cs156.team02.controllers;
+
+import edu.ucsb.cs156.team02.entities.UCSBSubject;
+import edu.ucsb.cs156.team02.entities.User;
+import edu.ucsb.cs156.team02.models.CurrentUser;
+import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import lombok.extern.slf4j.Slf4j;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.Optional;
+
+
+@Api(description = "UCSB Subjects")
+@RequestMapping("/api/systemInfo")
+@RestController
+@Slf4j
+public class UCSBSubjectController extends ApiController {
+
+    @Autowired
+    UCSBSubjectRepository uCSBSubjectRepository;
+
+    @ApiOperation(value = "List all UCSB subjects")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("/api/UCSBSubjects/all")
+    public Iterable<UCSBSubject> allUCSBSubjects() {
+        loggingService.logMethod();
+        Iterable<UCSBSubject> subjects = uCSBSubjectRepository.findAll();
+        return subjects;
+    }
+
+
+    @ApiOperation(value = "Create a new UCSB subject")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @PostMapping("/api/UCSBSubjects/post")
+    public UCSBSubject postUCSBSubject(
+            @ApiParam("subjectCode") @RequestParam String subjectCode,
+            @ApiParam("subjectTranslation") @RequestParam String subjectTranslation,
+            @ApiParam("deptCode") @RequestParam String deptCode,
+            @ApiParam("collegeCode") @RequestParam String collegeCode,
+            @ApiParam("relatedDeptCode") @RequestParam String relatedDeptCode,
+            @ApiParam("inactive") @RequestParam Boolean inactive) {
+        loggingService.logMethod();
+        CurrentUser currentUser = getCurrentUser();
+        log.info("currentUser={}", currentUser);
+
+        UCSBSubject uCSBSubject = new UCSBSubject();
+        uCSBSubject.setSubjectCode(subjectCode);
+        uCSBSubject.setSubjectTranslation(subjectTranslation);
+        uCSBSubject.setDeptCode(deptCode);
+        uCSBSubject.setCollegeCode(collegeCode);
+        uCSBSubject.setRelatedDeptCode(relatedDeptCode);
+        uCSBSubject.setInactive(inactive);
+        UCSBSubject savedUCSBSubject = uCSBSubjectRepository.save(uCSBSubject);
+        return savedUCSBSubject;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectController.java
@@ -92,7 +92,7 @@ public class UCSBSubjectController extends ApiController {
     @ApiOperation(value = "Get record of UCSB Subject with id")
     @PreAuthorize("hasRole('ROLE_USER')")
     @GetMapping("")
-    public ResponseEntity<String> getUCSBSubjectById123_admin(
+    public ResponseEntity<String> getUCSBSubjectById(
             @ApiParam("id") @RequestParam Long id) throws JsonProcessingException {
         loggingService.logMethod();
 
@@ -120,6 +120,8 @@ public class UCSBSubjectController extends ApiController {
         }
         return toe;
     }
+
+    
     
 
     

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests
@@ -1,0 +1,49 @@
+package edu.ucsb.cs156.team02.controllers;
+
+import edu.ucsb.cs156.team02.repositories.UserRepository;
+import edu.ucsb.cs156.team02.testconfig.TestConfig;
+import edu.ucsb.cs156.team02.ControllerTestCase;
+import edu.ucsb.cs156.team02.entities.UCSBSubject;
+import edu.ucsb.cs156.team02.entities.User;
+import edu.ucsb.cs156.team02.repositories.UCSBSubjectRepository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@WebMvcTest(controllers = TodosController.class)
+@Import(TestConfig.class)
+public class TodosControllerTests extends ControllerTestCase {
+
+     @MockBean
+    UCSBSubjectRepository uCSBSubjectRepository;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    public void api_UCSBSubject_admin_all__logged_out__returns_403() throws Exception {
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().is(403));
+    }
+
+}

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -128,4 +128,6 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+    
 }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -130,7 +130,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
     }
 
         
-        @WithMockUser(roles = { "USER" })
+    @WithMockUser(roles = { "USER" })
     @Test
     public void api_UCSBSubjects__user_logged_in__search_for_todo_that_does_not_exist() throws Exception {
 
@@ -149,6 +149,49 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         verify(uCSBSubjectRepository, times(1)).findById(eq(7L));
         String responseString = response.getResponse().getContentAsString();
         assertEquals("id 7 not found", responseString);
+    }
+
+     @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubject__user_logged_in__delete_todo_that_does_not_exist() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(98L).build();
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder().subjectCode("UCSBSubject 1").subjectTranslation("UCSBSubject 1").deptCode("UCSBSubject 1").collegeCode("UCSBSubject 1").relatedDeptCode("UCSBSubject 1").inactive(false).id(15L).build();
+        when(uCSBSubjectRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/UCSBSubjects/?id=15")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+        verify(uCSBSubjectRepository, times(1)).findById(15L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("record 15 not found", responseString);
+    }
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubject__user_logged_in__delete_subject() throws Exception {
+        // arrange
+
+        User otherUser = User.builder().id(98L).build();
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder().subjectCode("UCSBSubject 1").subjectTranslation("UCSBSubject 1").deptCode("UCSBSubject 1").collegeCode("UCSBSubject 1").relatedDeptCode("UCSBSubject 1").inactive(false).id(16L).build();
+        when(uCSBSubjectRepository.findById(eq(16L))).thenReturn(Optional.of(ucsbSubject1));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                delete("/api/UCSBSubjects/?id=16")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(uCSBSubjectRepository, times(1)).findById(16L);
+        verify(uCSBSubjectRepository, times(1)).deleteById(16L);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("record 16 deleted", responseString);
     }
     
 

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -30,9 +30,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@WebMvcTest(controllers = TodosController.class)
+@WebMvcTest(controllers = UCSBSubjectController.class)
 @Import(TestConfig.class)
-public class TodosControllerTests extends ControllerTestCase {
+public class UCSBSubjectControllerTests extends ControllerTestCase {
 
      @MockBean
     UCSBSubjectRepository uCSBSubjectRepository;
@@ -42,8 +42,31 @@ public class TodosControllerTests extends ControllerTestCase {
 
     @Test
     public void api_UCSBSubject_admin_all__logged_out__returns_403() throws Exception {
-        mockMvc.perform(get("/api/UCSBSubjects/all"))
+        mockMvc.perform(get("/api/UCSBSubject/admin/all"))
                 .andExpect(status().is(403));
     }
 
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubject__user_logged_in__returns_a_UCSBSubject_that_exists() throws Exception {
+
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder().subjectCode("UCSBSubject 1").subjectTranslation("UCSBSubject 1").deptCode("UCSBSubject 1").collegeCode("UCSBSubject 1").relatedDeptCode("UCSBSubject 1").inactive(false).id(7L).build();
+        when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject1));
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/ucsb_subjects?id=7"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(uCSBSubjectRepository, times(1)).findById(eq(7L));
+        String expectedJson = mapper.writeValueAsString(ucsbSubject1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -48,7 +48,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
     }
 
 
-    /*
+    
     @WithMockUser(roles = { "USER" })
     @Test
     public void api_ucsbsubject__user_logged_in__returns_a_UCSBSubject_that_exists() throws Exception {
@@ -60,7 +60,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject1));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=7"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -70,7 +70,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
-    */ //maybe unlimplemented yet?
+     //maybe unlimplemented yet?
 
     @WithMockUser(roles = { "USER" })
     @Test
@@ -128,6 +128,29 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }
+
+        
+        @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubjects__user_logged_in__search_for_todo_that_does_not_exist() throws Exception {
+
+        // arrange
+
+        User u = currentUserService.getCurrentUser().getUser();
+
+        when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=7"))
+                .andExpect(status().isBadRequest()).andReturn();
+
+        // assert
+
+        verify(uCSBSubjectRepository, times(1)).findById(eq(7L));
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals("id 7 not found", responseString);
+    }
+    
 
     
 }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
+
 @WebMvcTest(controllers = UCSBSubjectController.class)
 @Import(TestConfig.class)
 public class UCSBSubjectControllerTests extends ControllerTestCase {
@@ -42,15 +43,15 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
     @Test
     public void api_UCSBSubject_admin_all__logged_out__returns_403() throws Exception {
-        mockMvc.perform(get("/api/UCSBSubject/admin/all"))
+        mockMvc.perform(get("/api/UCSBSubjects/all"))
                 .andExpect(status().is(403));
     }
 
 
-
+    /*
     @WithMockUser(roles = { "USER" })
     @Test
-    public void api_UCSBSubject__user_logged_in__returns_a_UCSBSubject_that_exists() throws Exception {
+    public void api_ucsbsubject__user_logged_in__returns_a_UCSBSubject_that_exists() throws Exception {
 
         // arrange
 
@@ -59,13 +60,71 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject1));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/ucsb_subjects?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=7"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
 
         verify(uCSBSubjectRepository, times(1)).findById(eq(7L));
         String expectedJson = mapper.writeValueAsString(ucsbSubject1);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+    */ //maybe unlimplemented yet?
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void api_UCSBSubject_post__user_logged_in() throws Exception {
+        // arrange
+
+        UCSBSubject expectedUCSBSubject = UCSBSubject.builder().subjectCode("Test_SubjectCode").deptCode("Test_DeptCode").relatedDeptCode("Test_RelatedDeptCode").collegeCode("Test_CollegeCode").inactive(true).subjectTranslation("Test_SubjectTranslation").id(0L).build();
+                
+                
+                
+
+        when(uCSBSubjectRepository.save(eq(expectedUCSBSubject))).thenReturn(expectedUCSBSubject);
+
+        // act
+        MvcResult response = mockMvc.perform(
+                post("/api/UCSBSubjects/post?subjectCode=Test_SubjectCode&deptCode=Test_DeptCode&subjectTranslation=Test_SubjectTranslation&inactive=true&collegeCode=Test_CollegeCode&relatedDeptCode=Test_RelatedDeptCode")
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(uCSBSubjectRepository, times(1)).save(expectedUCSBSubject);
+        String expectedJson = mapper.writeValueAsString(expectedUCSBSubject);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(expectedJson, responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN" })
+    @Test
+    public void api_todos_admin_all__admin_logged_in__returns_all_todos() throws Exception {
+
+        // arrange
+        /*
+        User u1 = User.builder().id(1L).build();
+        User u2 = User.builder().id(2L).build();
+        User u = currentUserService.getCurrentUser().getUser();
+        */
+
+        UCSBSubject ucsbSubject1 = UCSBSubject.builder().subjectCode("UCSBSubject 1").deptCode("UCSBSubject 1").relatedDeptCode("UCSBSubject 1").collegeCode("UCSBSubject 1").id(1L).inactive(true).subjectTranslation("UCSBSubject 1").build();
+        UCSBSubject ucsbSubject2 = UCSBSubject.builder().subjectCode("UCSBSubject 2").deptCode("UCSBSubject 2").relatedDeptCode("UCSBSubject 2").collegeCode("UCSBSubject 2").id(2L).inactive(true).subjectTranslation("UCSBSubject 2").build();
+        UCSBSubject ucsbSubject3 = UCSBSubject.builder().subjectCode("UCSBSubject 3").deptCode("UCSBSubject 3").relatedDeptCode("UCSBSubject 3").collegeCode("UCSBSubject 3").id(1L).inactive(true).subjectTranslation("UCSBSubject 3").build();
+
+        ArrayList<UCSBSubject> expectedSubjects = new ArrayList<>();
+        expectedSubjects.addAll(Arrays.asList(ucsbSubject1, ucsbSubject2, ucsbSubject3));
+
+        when(uCSBSubjectRepository.findAll()).thenReturn(expectedSubjects);
+
+        // act
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/all"))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+
+        verify(uCSBSubjectRepository, times(1)).findAll();
+        String expectedJson = mapper.writeValueAsString(expectedSubjects);
         String responseString = response.getResponse().getContentAsString();
         assertEquals(expectedJson, responseString);
     }

--- a/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/team02/controllers/UCSBSubjectControllerTests.java
@@ -60,7 +60,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject1));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=7"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -97,7 +97,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
 
-    @WithMockUser(roles = { "ADMIN" })
+    @WithMockUser(roles = { "USER" })
     @Test
     public void api_todos_admin_all__admin_logged_in__returns_all_todos() throws Exception {
 
@@ -141,7 +141,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(uCSBSubjectRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects/?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/UCSBSubjects?id=7"))
                 .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -162,7 +162,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects/?id=15")
+                delete("/api/UCSBSubjects?id=15")
                         .with(csrf()))
                 .andExpect(status().isBadRequest()).andReturn();
 
@@ -183,7 +183,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/UCSBSubjects/?id=16")
+                delete("/api/UCSBSubjects?id=16")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -215,7 +215,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/UCSBSubjects/?id=67")
+                put("/api/UCSBSubjects?id=67")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
                         .content(requestBody)
@@ -242,7 +242,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/UCSBSubjects/?id=67")
+                put("/api/UCSBSubjects?id=67")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
                         .content(requestBody)


### PR DESCRIPTION
Add PUT (edit) endpoint for a single record in UCSBSubjects table. PUT endpoint works as expected on both local and heroku. 100% jacoco test and mutation coverage. 
